### PR TITLE
Use `fromJson()` to allow array syntax

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -14,10 +14,10 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@v1.2.0
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{ contains(['version-update:semver-patch', 'version-update:semver-minor'], steps.metadata.outputs.update-type }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auto-merge Dependabot PRs
+        if: ${{ contains(fromJson('["version-update:semver-patch", "version-update:semver-minor"]'), steps.metadata.outputs.update-type) }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use `fromJson()` to allow array syntax in the `if` statement of the automerge GitHub Action workflow.